### PR TITLE
Title: Port Flask's observation-based advice logic into Node

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -120,6 +120,15 @@
                             </div>
                         </div>
 
+                        <div class="form-group">
+                            <label for="observations">
+                                <span class="label-icon">🔍</span>
+                                Observations (Optional)
+                            </label>
+                            <textarea id="observations" name="observations" rows="3"
+                                placeholder="e.g., yellowing leaves, new shoots, pest signs, healthy growth..."></textarea>
+                        </div>
+
                         <button type="submit" class="submit-btn" id="submitBtn">
                             <span class="btn-text">Get Smart Recommendations</span>
                             <span class="btn-loader" style="display: none;">
@@ -198,6 +207,16 @@
                         </div>
                         <div class="card-content">
                             <p id="weatherAlert">Checking weather conditions...</p>
+                        </div>
+                    </div>
+
+                    <!-- Health Check Card (only shown if observations were provided) -->
+                    <div class="result-card health-card" id="healthCard" style="display: none;">
+                        <div class="card-header">
+                            <h3>🔍 Health Check</h3>
+                        </div>
+                        <div class="card-content">
+                            <p id="healthAdvice"></p>
                         </div>
                     </div>
 

--- a/public/script.js
+++ b/public/script.js
@@ -59,7 +59,7 @@ function setupEventListeners() {
   });
   
   // Input animations
-  document.querySelectorAll('input, select').forEach(input => {
+  document.querySelectorAll('input, select, textarea').forEach(input => {
     input.addEventListener('focus', function() {
       this.parentElement.style.transform = 'translateY(-2px)';
     });
@@ -78,7 +78,8 @@ async function handleFormSubmit(e) {
     cropName: formData.get('cropName').trim(),
     location: formData.get('location').trim(),
     sowingDate: formData.get('sowingDate') || null,
-    cropStage: formData.get('cropStage') || null
+    cropStage: formData.get('cropStage') || null,
+    observations: formData.get('observations') ? formData.get('observations').trim() : null
   };
   
   // Validation
@@ -162,6 +163,14 @@ function displayRecommendations(recommendations) {
   document.getElementById('irrigationAdvice').textContent = recommendations.irrigation;
   document.getElementById('cropCareAdvice').textContent = recommendations.cropCare;
   document.getElementById('weatherAlert').textContent = recommendations.weatherAlert;
+
+  const healthCard = document.getElementById('healthCard');
+  if (recommendations.healthAdvice) {
+    document.getElementById('healthAdvice').textContent = recommendations.healthAdvice;
+    healthCard.style.display = 'block';
+  } else {
+    healthCard.style.display = 'none';
+  }
 }
 
 async function loadPestAlerts(cropName) {

--- a/public/style.css
+++ b/public/style.css
@@ -222,17 +222,21 @@ body {
 }
 
 .form-group input,
-.form-group select {
+.form-group select,
+.form-group textarea {
   padding: 15px;
   border: 2px solid var(--border);
   border-radius: var(--border-radius);
   font-size: 1rem;
+  font-family: inherit;
+  resize: vertical;
   transition: var(--transition);
   background: var(--white);
 }
 
 .form-group input:focus,
-.form-group select:focus {
+.form-group select:focus,
+.form-group textarea:focus {
   outline: none;
   border-color: var(--primary-green);
   box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.1);

--- a/server.js
+++ b/server.js
@@ -32,6 +32,7 @@ function initializeDatabase() {
       location TEXT NOT NULL,
       sowing_date TEXT,
       crop_stage TEXT,
+      observations TEXT,
       timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
     );
 
@@ -72,7 +73,30 @@ function initializeDatabase() {
       console.error('Error creating tables:', err.message);
     } else {
       console.log('Database tables initialized');
+      migrateSchema();
       seedPestData();
+    }
+  });
+}
+
+// Migrate existing databases created before the `observations` column existed.
+// CREATE TABLE IF NOT EXISTS only applies to brand-new tables, so older
+// bhoomicare.db files need an explicit ALTER TABLE.
+function migrateSchema() {
+  db.all("PRAGMA table_info(user_queries)", (err, columns) => {
+    if (err) {
+      console.error('Migration check failed:', err.message);
+      return;
+    }
+    const hasObservations = columns.some(col => col.name === 'observations');
+    if (!hasObservations) {
+      db.run('ALTER TABLE user_queries ADD COLUMN observations TEXT', (alterErr) => {
+        if (alterErr) {
+          console.error('Migration error:', alterErr.message);
+        } else {
+          console.log('Migrated: added observations column to user_queries');
+        }
+      });
     }
   });
 }
@@ -166,8 +190,36 @@ async function getWeatherData(location) {
   }
 }
 
+// Ported from the old Flask /api/advice route: turns free-text farmer
+// observations ("yellowing leaves", "pest signs", etc.) into targeted advice.
+// Returns null when there's nothing useful to say, so callers can skip
+// showing a health card rather than displaying empty/generic filler.
+function getObservationAdvice(observations) {
+  if (!observations || !observations.trim()) {
+    return null;
+  }
+
+  const text = observations.toLowerCase();
+
+  if (text.includes('yellowing leaves') || text.includes('nutrient deficiency')) {
+    return '🟡 Signs point to nutrient deficiency (likely nitrogen or iron) or overwatering. Consider a balanced fertilizer application and check drainage.';
+  }
+  if (text.includes('new shoots') || text.includes('vigorous growth')) {
+    return '🌱 Vigorous growth detected — continue regular care, ensure adequate sunlight and nutrients, and keep an eye out for early pest activity.';
+  }
+  if (text.includes('pest signs') || text.includes('pest infestation')) {
+    return '🐛 Pest activity noted — inspect closely for common culprits (aphids, armyworms) and apply appropriate organic pest control promptly.';
+  }
+  if (text.includes('healthy growth')) {
+    return '✅ Your crop appears healthy — continue current practices and focus on preventative measures for common regional issues.';
+  }
+
+  // Any other observation text still gets a response, just a more general one
+  return '🔍 Based on your notes: maintain moderate irrigation and monitor for fungal growth if humidity is high. Consider organic fertilizer every two weeks.';
+}
+
 // AI-powered recommendations (simulated)
-function generateAIRecommendations(cropData, weatherData) {
+function generateAIRecommendations(cropData, weatherData, observations) {
   const { cropName, location, sowingDate, cropStage } = cropData;
   const { temperature, humidity, rainfall, windSpeed, description } = weatherData;
 
@@ -213,10 +265,13 @@ function generateAIRecommendations(cropData, weatherData) {
     weatherAlert = `🦠 High humidity and temperature favor fungal diseases. Apply preventive fungicide spray.`;
   }
 
+  const healthAdvice = getObservationAdvice(observations);
+
   return {
     irrigation: irrigationAdvice,
     cropCare: cropCareAdvice,
-    weatherAlert: weatherAlert || '✅ Weather conditions are favorable for crop growth.'
+    weatherAlert: weatherAlert || '✅ Weather conditions are favorable for crop growth.',
+    ...(healthAdvice ? { healthAdvice } : {})
   };
 }
 
@@ -228,13 +283,13 @@ app.get('/', (req, res) => {
 // Submit crop query
 app.post('/api/crop-query', async (req, res) => {
   try {
-    const { cropName, location, sowingDate, cropStage } = req.body;
+    const { cropName, location, sowingDate, cropStage, observations } = req.body;
 
     // Insert user query
     const queryResult = await new Promise((resolve, reject) => {
       db.run(
-        'INSERT INTO user_queries (crop_name, location, sowing_date, crop_stage) VALUES (?, ?, ?, ?)',
-        [cropName, location, sowingDate, cropStage],
+        'INSERT INTO user_queries (crop_name, location, sowing_date, crop_stage, observations) VALUES (?, ?, ?, ?, ?)',
+        [cropName, location, sowingDate, cropStage, observations || null],
         function(err) {
           if (err) reject(err);
           else resolve(this.lastID);
@@ -254,7 +309,8 @@ app.post('/api/crop-query', async (req, res) => {
     // Generate AI recommendations
     const recommendations = generateAIRecommendations(
       { cropName, location, sowingDate, cropStage },
-      weatherData
+      weatherData,
+      observations
     );
 
     // Store AI responses


### PR DESCRIPTION
## What changed
Flask's old `/api/advice` route read free-text observations ("yellowing
leaves", "pest signs", etc.) and returned targeted advice — logic Node
never had. This ports it over as an optional `healthAdvice` field.

## Changes
- New `getObservationAdvice()` in server.js, ported from Flask's keyword logic
- `user_queries` table: added `observations` column + auto-migration for
  existing databases (won't wipe or break current data)
- Frontend: optional "Observations" field on the form, new conditional
  "Health Check" card that only appears when there's real advice to show

## Testing
- [x] Ran migration against the actual pre-existing bhoomicare.db — column
      added successfully, existing rows untouched
- [x] POST /api/crop-query with "yellowing leaves" → correct healthAdvice
- [x] POST /api/crop-query with no observations → healthAdvice cleanly
      absent, no empty card shown